### PR TITLE
Main class in source-DeTeMedien_DE.module should be called DeTeMedien_DE

### DIFF
--- a/sources/source-DeTeMedien_DE.module
+++ b/sources/source-DeTeMedien_DE.module
@@ -9,7 +9,7 @@ Summary by github user Totole: 	TOS: has no limitations besides reselling downlo
 Version History
 2014-01-08	Initial migration to 2.11 and update regex's by lgaetz
 *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***/
-class DeTeMedien extends superfecta_base {
+class DeTeMedien_DE extends superfecta_base {
 
 
 	public $description = "http://www.detemedien.de/";


### PR DESCRIPTION
I think a little typo was made during migration of this module. Please find the fix in this pull request.
