### PR TITLE
Two new options for Squeezebox server module

### DIFF
--- a/sources/source-Send_to_Squeezebox_Server.module
+++ b/sources/source-Send_to_Squeezebox_Server.module
@@ -34,6 +34,8 @@ class Send_to_Squeezebox_Server extends superfecta_base {
     );
 
     function post_processing($cache_found, $winning_source, $first_caller_id, $run_param, $thenumber) {
+        if ($run_param['Display_Time'] == '') $run_param['Display_Time'] = '30';
+        if ($run_param['Player_Name'] == '') $run_param['Player_Name'] = '*';
         if (($run_param['URL_address'] != '') && ($first_caller_id != '')) {
             $thenumberformated = $thenumber;
             switch ($run_param['Display_Setting']) {


### PR DESCRIPTION
Added two new option. 
One for the duration of the information displayed in Squeezebox players (default=30 sec.) and
another option to be able to select an individual player receiving the information (default=all players in a network)
