### PR TITLE
Allow setting of filter lenght to specify the number of rightmost digits

### DIFF
--- a/sources/source-LDAP.module
+++ b/sources/source-LDAP.module
@@ -53,7 +53,7 @@ class LDAP extends superfecta_base {
             'default' => 1
         ),
         'Filter_Length' => array(
-            'description' => 'The number of rightmost digits to check for a match',
+            'description' => 'The number of rightmost digits to check for a match. Leave empty to check all digits.',
             'type' => 'number'
         )
     );


### PR DESCRIPTION
I have made a tiny addition to the LDAP module, that allows you to set a filter length specifying the number of rightmost digits to check for a match.

E.g., if it is set to 9, it would also find +31612345673 in the LDAP, while the original caller-ID is 0612345673.

If the setting is left empty, it will take the entire CID and compare it with a number in the LDAP.

I hope this is a useful contribution.
Thanks!
