### PR TITLE
Send_to_PushBullet: Ignore devices that are not provided with a nickname

### DIFF
--- a/sources/source-Send_to_PushBullet.module
+++ b/sources/source-Send_to_PushBullet.module
@@ -76,9 +76,9 @@ class Send_to_PushBullet extends superfecta_base {
 			$devices = json_decode($response);
 			$bar = array();
 			foreach ($devices->devices as $foo) {
-				$bar1 = $foo->nickname;
-				$bar2 = $foo->iden;
-				$bar[$bar2]=$bar1;
+				if (isset($foo->iden) && isset($foo->nickname)) {
+					$bar[$foo->iden] = $foo->nickname;
+				}
 			}
 			$this->source_param['Device']['option'] = $bar;
 		}


### PR DESCRIPTION
Encountered PushBullet JSON responses that listed some devices without a nickname, causing source to fail. Minor change to make code resilient to that.
