### PR TITLE
Patch for issues with special characters ä,ö,ü etc.

### DIFF
--- a/Superfecta.class.php
+++ b/Superfecta.class.php
@@ -202,7 +202,7 @@ class Superfecta implements \BMO {
 				// convert CNAM to UTF-8 to fix
 				if (function_exists('mb_convert_encoding')) {
 					$this->out("Converting result to UTF-8");
-					$callerid = mb_convert_encoding($callerid, "UTF-8");
+					$callerid = mb_convert_encoding($callerid, "UTF-8", "ISO-8859-1");
 				}
 				
 				//send off

--- a/includes/superfecta_base.php
+++ b/includes/superfecta_base.php
@@ -506,7 +506,7 @@ class superfecta_base {
 	}
 
 	function _utf8_decode($string) {
-		$string = html_entity_decode($string);
+		$string = html_entity_decode($string, ENT_COMPAT, "ISO-8859-1");
 		$tmp = $string;
 		$count = 0;
 		while ($this->isutf8($tmp)) {


### PR DESCRIPTION
Search results in Germany have problems with special characters UTF8<->ISO-8859-1 - this patch should fix it.