### PR TITLE
Return organization name if no firstname/lastname found

### DIFF
--- a/includes/oauth-google/Google_Service_ReadContacts.php
+++ b/includes/oauth-google/Google_Service_ReadContacts.php
@@ -82,6 +82,10 @@ class Google_Service_ReadContacts
         $output = array();
         foreach ($result as $entry) {
             $name = $entry->getElementsByTagName('title')->item(0)->textContent;
+            // if no firstname/lastname found, try to get organization name
+            if ($name == '') {
+                $name = $entry->getElementsByTagName('orgName')->item(0)->textContent;
+            }
             $phoneNos = $entry->getElementsByTagName('phoneNumber');
             foreach ($phoneNos as $number) {
                 $no = $this->cleanNumber($number->textContent);


### PR DESCRIPTION
If there is no firstname and no lastname information in the contact found, try to return the organization name.
See issue report here: https://issues.freepbx.org/browse/FREEPBX-17650