### PR TITLE
Fix special character and umlaut problems

### DIFF
--- a/Superfecta.class.php
+++ b/Superfecta.class.php
@@ -188,23 +188,13 @@ class Superfecta implements \BMO {
 			$found = false;
 			if (!empty($callerid)) {
 				$found = true;
-				//$first_caller_id = _utf8_decode($first_caller_id);
 				$callerid = trim(strip_tags($callerid));
-				if ($superfecta->isCharSetIA5()) {
-					$callerid = $superfecta->stripAccents($callerid);
-				}
-				//Why?
-				$callerid = preg_replace("/[\";']/", "", $callerid);
-				//limit caller id to the first 60 char
-				$callerid = substr($callerid, 0, 60);
-				
 				// Display issues on phones and CDR with special characters
 				// convert CNAM to UTF-8 to fix
-				if (function_exists('mb_convert_encoding')) {
+				if (function_exists('mb_convert_encoding') && (! $superfecta->isutf8($callerid))) {
 					$this->out("Converting result to UTF-8");
 					$callerid = mb_convert_encoding($callerid, "UTF-8");
 				}
-				
 				//send off
 				$superfecta->send_results($callerid);
 			}


### PR DESCRIPTION
stripAccents() treats UTF8-strings like ASCII-strings and changes special characters to something like 7-Bit-characters without accents. If there are still phones out there which are not able to display at least ISO-8859-1 characters like á, ä, â, ... they should be replaced by newer ones.
However, after stipAccents() was called in line 194, the content of the unicode string was destroyed anyway and so the original line 205 didn't make sense any more.
Also I don't see any reason why one should cut off a callers name after 60 characters. This should be done by the phone itself if it doesn't have the capability to display longer names.
Finally if the name is already encoded in UTF8 (like results from databases or Google Contacts) it shouldn't be converted a second time.
After these changes Google Contact information was eventually correctly displayed on different phones even with umlauts or special characters. I tested this with Snom, Yealink and Zoiper.