### PR TITLE
Update Superfecta.class.php

### DIFF
--- a/Superfecta.class.php
+++ b/Superfecta.class.php
@@ -161,7 +161,8 @@ class Superfecta implements \BMO {
 			//if a prefix lookup is enabled, look it up, and truncate the result to 10 characters
 			///Clean these up, set NULL values instead of blanks then don't check for ''
 			$superfecta->set_Prefix('');
-			if ((isset($scheme_param['Prefix_URL'])) && (trim($scheme_param['Prefix_URL']) != '')) {
+			// fix: if ((isset($scheme_param['Prefix_URL'])) && (trim($scheme_param['Prefix_URL']) != '')) {
+			if ((isset($options['scheme_settings']['Prefix_URL'])) && (trim($options['scheme_settings']['Prefix_URL'])) != '') {
 				$start_time = $superfecta->mctime_float();
 
 				$superfecta->set_Prefix($superfecta->get_url_contents(str_replace("[thenumber]", $cnum, $options['scheme_settings']['Prefix_URL'])));
@@ -171,7 +172,8 @@ class Superfecta implements \BMO {
 				} else {
 					$this->out(_("Prefix Url defined but result was empty"));
 				}
-				$this->out(sprintf(_("Prefix Url result took %s seconds."),number_format((mctime_float() - $start_time), 4)));
+				// fix: $this->out(sprintf(_("Prefix Url result took %s seconds."),number_format((mctime_float() - $start_time), 4)));
+				$this->out(sprintf(_("Prefix Url result took %s seconds."),number_format(($superfecta->mctime_float() - $start_time), 4)));
 			}
 
 			$trunk_info['callerid'] = $cnum;


### PR DESCRIPTION
The fact is that the $scheme_param array does not exist in the code, so this condition will never be fulfilled. Instead, it was necessary to use another array: $options.
The mctime_float function is actually a method of the superfcta_base class.
In superfecta_base.php change "protected $prefix = '';" to "public $prefix = '';"