### PR TITLE
removing duplicated CID prefix in ConnectWise superfecta source

### DIFF
--- a/sources/source-ConnectWise.module
+++ b/sources/source-ConnectWise.module
@@ -203,6 +203,6 @@ EOT;
 		else if($debug) {
 			$this->DebugPrint("Not found in ConneceWise");
 		}
-		return $run_param['CNAM_prefix'].$caller_id;
+		return $caller_id;
 	}
 }


### PR DESCRIPTION
The ConnectWise superfecta source returns a the CNAM_prefix twice, as it is prepended to caller_id on line 201, then prepended a second time on line 206 in sources/source-ConnectWise.module.

Removed the second, redundant prepending of CNAM_prefix on line 206