### PR TITLE
Update source-Send_to_email.module

### DIFF
--- a/sources/source-Send_to_email.module
+++ b/sources/source-Send_to_email.module
@@ -59,7 +59,9 @@ class Send_to_Email extends superfecta_base {
 			$cnam = $run_param['Default_CNAM'];
 		}
 
-		if(isset($this->trunk_info['dnid'])){
+		if (isset($this->trunk_info['extension'])) {
+			$from_did = $this->trunk_info['extension'];
+		} elseif(isset($this->trunk_info['dnid'])){
 			$from_did = $this->trunk_info['dnid'];
 		} elseif (isset($run_param['Default_DID']) &&  $run_param['Default_DID'] != "") {
 			$from_did = $run_param['Default_DID'];


### PR DESCRIPTION
I do have a Telekom SIP Trunk (Germany) which is one Trunk in asterisk with several inbound routes ( xxxxx0 - xxxxx79). For now only the main number xxxxx0 was shown in email as DID. With this change, e.g. xxxxx79 is shown as DID.

Superfecta always logged it right and i wondered why the info in the email was wrong: https://github.com/FreePBX/superfecta/blob/b46680134a81b8949b5c08410c0d34dfbfd145a1/Superfecta.class.php#L83