### PR TITLE
add new name variable to emails to allow to generate a proper URL

### DIFF
--- a/sources/source-Send_to_email.module
+++ b/sources/source-Send_to_email.module
@@ -29,7 +29,7 @@ class Send_to_Email extends superfecta_base {
 		'Message_Body' => array(
 			'description' => 'Content for the body of the email. Substitute [NUMBER], [NAME] and [DID] for CID variables.',
 			'type' => 'textarea',
-			'default' => 'Incoming call to [DID] from [NAME] at [NUMBER]. Automated notification email sent by the POSSA Superfecta Caller ID Module'
+			'default' => 'Incoming call to [DID] from [NAME] at [NUMBER]. [NAME2] replaces spaces with plus in [NAME] for URL generation. Automated notification email sent by the POSSA Superfecta Caller ID Module'
 		),
 		'Default_CNAM' => array(
 			'description' => 'If no CNAM is found, input a default name to use for the email notice, the user will receive an email with the number and this default name. Leave blank to send no email if no CNAM is found.',
@@ -50,6 +50,7 @@ class Send_to_Email extends superfecta_base {
 
     function post_processing($cache_found, $winning_source, $first_caller_id, $run_param, $thenumber) {
 		$cnam = "";
+		$cnam2 = "";
 		$headers = "";
 		$from_did = "";
 		if ($first_caller_id != "")  {
@@ -58,7 +59,9 @@ class Send_to_Email extends superfecta_base {
 		else if ($run_param['Default_CNAM'] != "")  {
 			$cnam = $run_param['Default_CNAM'];
 		}
-
+		
+		$cnam2 = str_replace(' ', '+', $cnam);
+		
 		if(isset($this->trunk_info['dnid'])){
 			$from_did = $this->trunk_info['dnid'];
 		} elseif (isset($run_param['Default_DID']) &&  $run_param['Default_DID'] != "") {
@@ -86,6 +89,8 @@ class Send_to_Email extends superfecta_base {
 		}
 		$body = str_replace('[NAME]', $cnam, $body);
 		$body = str_replace('[name]', $cnam, $body);
+		$body = str_replace('[NAME2]', $cnam2, $body);
+		$body = str_replace('[name2]', $cnam2, $body);
 		$body = str_replace('[NUMBER]', $thenumber, $body);
 		$body = str_replace('[number]', $thenumber, $body);
 		$body = str_replace('[DID]', $from_did, $body);


### PR DESCRIPTION
This change creates a new variable for the email module that changes the spaces ( ) in the CNAM to plus (+). This is done so that the CNAM can be used in a link. For URLs, the spaces need to be a +or it will cut off the URL.

http://192.168.0.1/cgi-bin/addphonenumber.pl?key=8005551234&val=First+Last

PBX is just a hobby for me and I never programmed in PHP. I use the phonebook to whitelist all calls. All calls that come in go through a challenging process to filter out unwanted spam calls. This works very well. However, my wife doesn't know how to enter the phone number in the phonebook. So I created a link she can click if she wants to add someone new. 

#!/usr/bin/perl -w
use CGI qw(param);
my $key = param("key");
my $val = param("val");
print "Content-type: text/html\n\n";
use Asterisk::Manager;
my $astman = new Asterisk::Manager;
$astman->user('admin');
$astman->secret('password');
$astman->host('localhost');
$astman->connect || die $astman->error . "\n";
$astman->sendcommand(Action => 'DBPut', Family => 'cidname', Key => "$key", Val => "$val");
my @result = $astman->sendcommand(Event => 'DBGetResponse');
print @result;
print "\n";
$astman->disconnect;