### PR TITLE
Compatibility with PHP 8 (PBX v.17) for Regular_Expressions_2

### DIFF
--- a/sources/source-Regular_Expressions_2.module
+++ b/sources/source-Regular_Expressions_2.module
@@ -44,13 +44,15 @@ class Regular_Expressions_2 extends superfecta_base
 
 		if (!empty($run_param['URL']) && !empty($run_param['Regular_Expressions'])) { //these are the only mandative values
 			$run_param['URL'] = str_replace('$thenumber', $thenumber, $run_param['URL']);
-			$post = false;
+			$post = [];
 
 			//parse POST data if present
 			if (!empty($run_param['POST_Data'])) {
 				preg_match_all('/\s*"(?P<key>.*)"\s*=\s*"(?P<value>.*)"/m', $run_param['POST_Data'], $matches);
 				for ($i = 0; $i < count($matches['key']); $i++)
 					$post[$matches['key'][$i]] = $matches['value'][$i] == '$thenumber' ? $thenumber : $matches['value'][$i];
+
+				if (count($post) == 0) $post = false;
 
 				if ($this->isDebug() && is_array($post))
 					$this->DebugPrint(sprintf(_('Parsed POST data is: %s'), str_replace('%20', ' ', http_build_query($post, '', ', ', PHP_QUERY_RFC3986))));


### PR DESCRIPTION
Converting bool to array is deprecated and make the lookup fail.

Reported by @polcape in https://github.com/Massi-X/freepbx-carddavmiddleware-ui/issues/17