### PR TITLE
Fix null warning PHP 8

### DIFF
--- a/sources/source-Regular_Expressions_2.module
+++ b/sources/source-Regular_Expressions_2.module
@@ -37,7 +37,7 @@ class Regular_Expressions_2 extends superfecta_base
 
 	function get_caller_id($thenumber, $run_param = array())
 	{
-		$caller_id = null;
+		$caller_id = '';
 
 		if (!$this->isDebug())
 			$this->DebugPrint(_('Running regex_2 scheme. To get logs please run debug mode.'));


### PR DESCRIPTION
Found by @polcape here https://github.com/Massi-X/freepbx-carddavmiddleware-ui/issues/17#issuecomment-2364610938

Fixes null exception when POST value is empty on PHP 8+ (FPBX 17)