### PR TITLE
Contact Manager lookup fails if search-string contains '+'

### DIFF
--- a/sources/source-FreePBX_Contactmanager.module
+++ b/sources/source-FreePBX_Contactmanager.module
@@ -26,7 +26,7 @@ class FreePBX_Contactmanager extends superfecta_base {
 
 	function get_caller_id($thenumber, $run_param=array()) {
 		$caller_id = null;
-		$data = FreePBX::Contactmanager()->lookupByUserID(-1, $thenumber,"/\D/");
+		$data = FreePBX::Contactmanager()->lookupByUserID(-1, $thenumber,"/[^\+\d]/");
 		if(empty($data)){
 			return null;
 		}


### PR DESCRIPTION
If the CID is transmitted with a leading +, the lookup from the contact manager database fails, because the used regex deletes every character but numbers.

Bugfix FreePBX/issue-tracker#587