### PR TITLE
Fix whoops error if lookup returns no CNAM

### DIFF
--- a/sources/source-Twilio.module
+++ b/sources/source-Twilio.module
@@ -18,7 +18,7 @@
  * along with this program.	If not, see <http://www.gnu.org/licenses/>.
  *
  * 04.28.2016 initial release by James Finstrom jfinstrom@sangoma.com
- *
+ * 05.19.2025 Fix oops error caused by misformatted numbers
  */
 
 class Twilio extends superfecta_base{
@@ -49,6 +49,8 @@ class Twilio extends superfecta_base{
 			$this->DebugPrint("Lookup Error");
 			$this->DebugPrint($data['message']);
 		}
-		return($data['caller_name']['caller_name']);
+		if(isset($data['caller_name']) ){
+			return($data['caller_name']['caller_name']);
+		}
 	}
 }


### PR DESCRIPTION
The Twilio API only supports USA phone number lookups for CNAM. If the number is misformatted, or if the lookup is done on a non USA number (i.e. Canada) then the API returns null for CNAM and triggers a whoops error.