### PR TITLE
Fixes for German sources

### DIFF
--- a/sources/source-DasTelefonBuch_Germany.module
+++ b/sources/source-DasTelefonBuch_Germany.module
@@ -13,6 +13,7 @@
  * Version History:
  * 2017-03-21	Initial Module for DasTelefonBuch_Germany
  * 2017-11-09	If the Caller ID is 'unknown', 'anonymous' or empty then skip the check
+ * 2025-08-13   Made international format (+49...) working.
  *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***/
 
 class DasTelefonBuch_Germany extends superfecta_base {
@@ -26,6 +27,7 @@ class DasTelefonBuch_Germany extends superfecta_base {
 
 	function get_caller_id($thenumber, $run_param=array()) {
 		$this->DebugPrint(_("Searching"). "https://www.dastelefonbuch.de ... ");
+		$thenumber = (strlen($thenumber) > 0 && $thenumber[0] === '+') ? '00' . substr($thenumber, 1) : $thenumber;
 
 		
 		if($thenumber !== 'anonymous' && $thenumber !== 'unknown' && $thenumber !== ''){

--- a/sources/source-DeTeMedien_DE.module
+++ b/sources/source-DeTeMedien_DE.module
@@ -10,6 +10,7 @@
  *        2014-01-08   Initial migration to 2.11 and update regex's by lgaetz
  *        2014-03-25   Regex fix by Håkan
  *        2014-07-23   Regex fix by kossmac
+ *        2025-08-11   Regex fix by JaCoTec, works now also with intl numbers (+49...)
  */
 class DeTeMedien_DE extends superfecta_base {
 
@@ -19,6 +20,7 @@ class DeTeMedien_DE extends superfecta_base {
 	
 	function get_caller_id($thenumber, $run_param=array()) {
 		$caller_id = null;
+		$thenumber = (strlen($thenumber) > 0 && $thenumber[0] === '+') ? '00' . substr($thenumber, 1) : $thenumber;
 		$this->DebugPrint(sprintf(_("Searching http://www.detemedien.de/ for %s..."),$thenumber));
 
 		// url from ver. 2.2.x still working 2014-01-08
@@ -32,13 +34,15 @@ class DeTeMedien_DE extends superfecta_base {
 			'/class="name " onmouseover="" onMouseOut=""><span class="">(.*?)<\/span>/',    // working 2014-07-23
 			'/class="name "><span class="">(.*?)<\/span>/',    // working 2014-07-23
 			'/class="name " onmouseover="" onmouseout=""><span class="">(.*?)<\/span>/',    // working 2014-07-23
+			'/class="hitlnk_name">(.*?)<\/a>/',    // working 2025-08-11
 		);
 
 		if ($this->SearchURL($url, $regexp, $match, NULL, TRUE)) {
 			$caller_id = $this->ExtractMatch($match);
 		}
+		$caller_id = isset($caller_id)?$caller_id:'';
 
-		return(str_replace("&nbsp;", '', $caller_id));
+		return($caller_id);
 	}
 
 }

--- a/sources/source-TellowsAPI.module
+++ b/sources/source-TellowsAPI.module
@@ -35,17 +35,13 @@ class TellowsAPI extends superfecta_base {
 		// $thuenumber must be in E164 format: [+][country code][subscriber number including area code]
 	
 	    $apihash = $run_param['Tellows_Key'];
-	    if ($apihash <> '') {
-		   $url = "https://www.tellows.de/basic/num/$thenumber?json=1&partner=tellowskey&apikey=$apihash";
-           $this->DebugPrint(_('Request with API key')." ".$apihash);
-		} else {
-		   $url = "https://www.tellows.de/basic/num/$thenumber?json=1";
-           $this->DebugPrint(_('Request without API key'));
-        }			
+        $url = "https://www.tellows.de/basic/num/$thenumber?json=1&apikeyMd5=$apihash";
+        $this->DebugPrint(_('Request with API key')." ".$apihash);
+
+        // Chcek for a valid response. In case the API key is wrong or not MD5 format, the response will not be valid JSON.
 		$json = $this->get_url_contents($url);
-		$errchk = strpos(strtolower($json),"error");
-		if ($errchk > 0) {
-           $this->DebugPrint(_("Invalid request format"));			
+		if (json_decode($json) == null) {
+           $this->DebugPrint(_("Invalid response. Check if your API key is valid and in MD5 format"));			
 		} else {
 		   $result = json_decode($json,true);
 		   $value = $result['tellows']['score'];
@@ -57,6 +53,7 @@ class TellowsAPI extends superfecta_base {
 
 			   $score = $value;
 			   if ($score >= $run_param['SPAM_Threshold'] AND $comments >= $run_param['COMMENTS_Threshold'] AND $searches >= $run_param['SEARCHES_Threshold']) {
+			       $this->spam_count = intval($score);		// Set Spam count (Which reflects to the Threshold for the SPAM interception)
 				   $this->spam = true;
 				   $this->DebugPrint(" "._("determined to be SPAM"));
 			   } else {


### PR DESCRIPTION
Tellows:
- Fixed the script (it did not work at all)
- Script now passes the SPAM score (spam_count), so it works with SPAM interception

DeTeMedien:
- Fixed broken RegEx (Response format was changed)
- Works now also if international format (+49...) is supplied

DasTelefonbuch:
- Works now also if international format (+49...) is supplied