### PR TITLE
gitIssue-374 Fix remaining deprecated ${var} string interpolation in sources

### DIFF
--- a/sources/source-CapsuleCRM.module
+++ b/sources/source-CapsuleCRM.module
@@ -114,7 +114,7 @@ class CapsuleCRM extends superfecta_base
         // return the person name and there organisation if it is set.
         if ($item->type == 'person') {
             $organisation = $item->organisation == null ? '' : "- {$item->organisation->name}";
-            return trim("{$item->firstName} {$item->lastName} ${organisation}");
+            return trim("{$item->firstName} {$item->lastName} {$organisation}");
         }
 
         // party is an organisation so just return the name

--- a/sources/source-LDAP.module
+++ b/sources/source-LDAP.module
@@ -174,7 +174,7 @@ class LDAP extends superfecta_base {
             switch ($run_param['LDAP_Server']) {
                 case LDAP_OPENDIRECTORY:
                 case LDAP_OPENLDAP:
-                    $dn = "ou=${ou},${dc}";
+                    $dn = "ou={$ou},{$dc}";
                     break;
 
                 case LDAP_CUSTOM:
@@ -182,7 +182,7 @@ class LDAP extends superfecta_base {
                     break;
              }
         } else {
-            $dn = "${dc}";
+            $dn = "{$dc}";
         }
 
         $this->DebugEcho("Searching {$dn} ... ");

--- a/sources/source-Send_to_MythTV.module
+++ b/sources/source-Send_to_MythTV.module
@@ -70,7 +70,7 @@ class Send_to_Mythtv extends superfecta_base {
             socket_close($sock);
 
 
-            $this->DebugPrint("Send to mythtv: ${mythtv_text}");
+            $this->DebugPrint("Send to mythtv: {$mythtv_text}");
         }
 
         return($thenumber);

--- a/sources/source-Send_to_YAC.module
+++ b/sources/source-Send_to_YAC.module
@@ -34,7 +34,7 @@ class Send_to_YAC extends superfecta_base {
             $yac_text = $yac_cnam . '~' . $thenumber;
             shell_exec('/bin/echo -e -n "@CALL' . $yac_text . '"|nc -w 1 ' . $run_param['Server_address'] . ' ' . $run_param['Server_TCP_Port'] . '');
 
-            $this->DebugPrint("Send to YAC: ${yac_text}");
+            $this->DebugPrint("Send to YAC: {$yac_text}");
         }
 
         return($thenumber);


### PR DESCRIPTION
Fixes #374.

PHP 8.2 deprecates `"${var}"` inside double-quoted strings. The deprecation is raised at **compile time** when the file is included, and the FreePBX bootstrap's Whoops error handler escalates it to an `ErrorException` — so a source file containing the syntax throws on `include`, before its class can be instantiated. In practice this makes the **LDAP source unusable on FreePBX 17** no matter how it is configured.

The sweep from #988/#989 (PR #371, shipped in 17.0.6) removed most occurrences; this completes it. Mechanical `${var}` → `{$var}` on the five remaining lines:

| File | Lines |
|---|---|
| `sources/source-LDAP.module` | 177, 185 |
| `sources/source-CapsuleCRM.module` | 117 |
| `sources/source-Send_to_MythTV.module` | 73 |
| `sources/source-Send_to_YAC.module` | 37 |

No behavior change — `{$var}` produces identical output on all supported PHP versions.

**Tested:** all four files pass `php -l` on PHP 8.2.28 (Debian 12). The LDAP source fix is additionally verified end-to-end on a production FreePBX 17.0 / superfecta 17.0.7 install: with the patched file, a scheme debug run returns the correct CNAM from an LDAP phonebook in ~13 ms; unpatched, the include throws `Whoops\Exception\ErrorException: Using ${var} in strings is deprecated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)